### PR TITLE
versionary: add get_applicable method

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,5 @@ Keep the list in alfabetical order please.
 
  * Devhouse Spindle {opensource@wearespindle.com}
  * Marco Vellinga {info@itstars.nl}
+ * Konrad Weihmann {kweihmann@outlook.com}
+

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,7 +1,7 @@
 from pytest import raises
 
 from versionary.decorators import versioned
-from versionary.exceptions import DuplicateVersionException, InheritanceException, InvalidVersionException
+from versionary.exceptions import DuplicateVersionException, InheritanceException, InvalidVersionException, NoApplicableVersion
 
 from .utils.mixed_members import MixedClass, mixed_func
 from .utils.versioned_members import MyClass, MyInheritanceClass, my_function, your_function
@@ -22,6 +22,27 @@ def test_decorator_for_classes_without_number():
     """
     assert MyClass.v1().hello() == 3
     assert MyClass.v2().hello() == 4
+
+
+def test_decorator_for_classes_get_applicable_max():
+    """
+    Test the decorator for latest classes via get_applicable.
+    """
+    assert MyClass.get_applicable()().hello() == 4
+    assert MyClass.get_applicable(minver=2)().hello() == 4
+    assert MyClass.get_applicable(maxver=1)().hello() == 3
+    with raises(NoApplicableVersion):
+        MyClass.get_applicable(minver=100)().hello()
+
+def test_decorator_for_classes_get_applicable_min():
+    """
+    Test the decorator for earliest classes via get_applicable.
+    """
+    assert MyClass.get_applicable(func=min)().hello() == 3
+    assert MyClass.get_applicable(minver=2, func=min)().hello() == 4
+    assert MyClass.get_applicable(maxver=1, func=min)().hello() == 3
+    with raises(NoApplicableVersion):
+        MyClass.get_applicable(minver=100, func=min)().hello()
 
 
 def test_decorator_for_class_inheritance_without_number():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,7 @@ def test_create_proxy_class():
     """
     base_name = 'base_name'
 
-    proxy = create_proxy_class(base_name)
+    proxy = create_proxy_class(base_name, 123)
 
     message = 'Cannot call `base_name` directly, use versioned attributes instead (`base_name`.vX)'
 

--- a/versionary/decorators.py
+++ b/versionary/decorators.py
@@ -116,7 +116,7 @@ def versioned(number=None):
             validate_inheritance_for_class(member)
 
         # Get or create the proxy class to return.
-        proxy = version_members.get('proxy', create_proxy_class(name))
+        proxy = version_members.get('proxy', create_proxy_class(name, module))
 
         # Add new version method to this proxy class.
         setattr(proxy, '%s%s' % (PROXY_VERSION_TAG, version), staticmethod(member))

--- a/versionary/exceptions.py
+++ b/versionary/exceptions.py
@@ -41,3 +41,10 @@ class NotCallableException(Exception):
     Raised when trying to call the ProxyClass which shouldn't be called.
     """
     pass
+
+
+class NoApplicableVersion(Exception):
+    """
+    Raised when no version matching the criteria was found.
+    """
+    pass


### PR DESCRIPTION
versionary: add get_applicable method

which adds the possibility to select a version based on passed
minium and maximum versions requirements,
so we do not need to know what versions are actually implemented and
can select the highest available version within the given boundaries.

If no version was found a new exception NoApplicableVersion is raised

